### PR TITLE
[STEP13], [STEP14] 진행

### DIFF
--- a/src/main/java/com/consertreservation/api/cron/UserToken/UserTokenCron.java
+++ b/src/main/java/com/consertreservation/api/cron/UserToken/UserTokenCron.java
@@ -1,7 +1,7 @@
 package com.consertreservation.api.cron.UserToken;
 
-import com.consertreservation.domain.usertoken.application.UserTokenService;
-import com.consertreservation.domain.usertoken.application.dto.ResultUserTokenServiceDto;
+import com.consertreservation.application.queue.application.QueueService;
+import com.consertreservation.application.queue.application.dto.ResultQueueServiceDto;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -9,40 +9,29 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
+import static com.consertreservation.application.queue.constant.QueueConst.COUNT_OF_ACTIVE_USER_TOKEN;
+
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class UserTokenCron {
 
-    private static final int COUNT_OF_UPDATED_USER_TOKEN = 10;
     @Value("${schedule.userToken.success.active}")
     private boolean updateSuccess;
     @Value("${schedule.userToken.expire.active}")
     private boolean updateExpired;
-    private final UserTokenService userTokenService;
+    private final QueueService queueService;
 
     @Scheduled(cron = "${schedule.userToken.success.cron}")
     public void updateWaitToSuccess() {
         if (!updateSuccess) {
             return;
         }
-        log.info("====== 대기열 유저 10명을 입장 시작 ======");
-        List<ResultUserTokenServiceDto> userTokens = userTokenService.getWaitOfUserTokens(COUNT_OF_UPDATED_USER_TOKEN);
-        userTokenService.updateUserTokensStatus(userTokens.stream().map(ResultUserTokenServiceDto::id).toList(), "SUCCESS");
-        log.info("====== 대기열 유저 10명을 입장 종료 ======");
-    }
-
-    @Scheduled(cron = "${schedule.userToken.expire.cron}")
-    public void updateSuccessToExpired() {
-        if (!updateExpired) {
-            return;
-        }
-        log.info("====== 입장한 유저 10명을 만료 시작 ======");
-        List<ResultUserTokenServiceDto> userTokens = userTokenService.getSuccessOfUserTokens(COUNT_OF_UPDATED_USER_TOKEN);
-        for (ResultUserTokenServiceDto userToken : userTokens) {
-            log.info("userToken={}", userToken);
-        }
-        userTokenService.updateUserTokensStatus(userTokens.stream().map(ResultUserTokenServiceDto::id).toList(), "EXPIRED");
-        log.info("====== 입장한 유저 10명을 만료 종료 ======");
+        log.info("====== 대기열 유저 250명을 입장 시작 ======");
+        queueService.clearActiveQueue();
+        List<ResultQueueServiceDto> items = queueService.getNextItemsInWaitingQueue(COUNT_OF_ACTIVE_USER_TOKEN);
+        items.forEach(item -> queueService.addItemToActiveQueue(item.userId()));
+        queueService.removeItemToWaitingQueue(COUNT_OF_ACTIVE_USER_TOKEN);
+        log.info("====== 대기열 유저 250명을 입장 종료 ======");
     }
 }

--- a/src/main/java/com/consertreservation/application/queue/application/QueueService.java
+++ b/src/main/java/com/consertreservation/application/queue/application/QueueService.java
@@ -1,0 +1,61 @@
+package com.consertreservation.application.queue.application;
+
+import com.consertreservation.application.redis.RedisService;
+import com.consertreservation.application.queue.application.dto.ResultQueueServiceDto;
+import com.consertreservation.application.queue.constant.QueueConst;
+import com.consertreservation.domain.usertoken.application.UserTokenService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.util.*;
+
+@Service
+@RequiredArgsConstructor
+public class QueueService {
+
+    private final RedisService redisService;
+    private final UserTokenService userTokenService;
+
+    public void addItemToWaitingQueue(Long userId) {
+        redisService.addItemToSortedSet(QueueConst.WAITING_QUEUE, String.valueOf(userId),
+                getTimestamp(LocalDateTime.now()));
+    }
+
+    public void removeItemToWaitingQueue(int size) {
+        redisService.removeItemsInSortedSet(QueueConst.WAITING_QUEUE, 0, size);
+    }
+
+    public void addItemToActiveQueue(Long userId) {
+        redisService.addItemToHash(QueueConst.ACTIVE_QUEUE, String.valueOf(userId), "1");
+    }
+
+    public List<ResultQueueServiceDto> getNextItemsInWaitingQueue(int size) {
+        List<Long> ids = redisService.getItemsInSortedSet(QueueConst.WAITING_QUEUE, 0, size)
+                .stream()
+                .map(userId -> Long.valueOf(String.valueOf(userId)))
+                .toList();
+
+        return userTokenService.getUserTokens(ids)
+                .stream()
+                .map(ResultQueueServiceDto::from)
+                .toList();
+    }
+
+    public Long calculateRemainOfWaitingOrder(Long userId) {
+       return redisService.getItemRank(QueueConst.WAITING_QUEUE, String.valueOf(userId)) + 1;
+    }
+
+    public boolean isInActiveQueue(Long userId) {
+        return redisService.existInHash(QueueConst.ACTIVE_QUEUE, String.valueOf(userId));
+    }
+
+    public void clearActiveQueue() {
+        redisService.deleteAllInHash(QueueConst.ACTIVE_QUEUE);
+    }
+
+    private long getTimestamp(LocalDateTime date) {
+        return Timestamp.valueOf(date).getTime();
+    }
+}

--- a/src/main/java/com/consertreservation/application/queue/application/dto/ResultQueueServiceDto.java
+++ b/src/main/java/com/consertreservation/application/queue/application/dto/ResultQueueServiceDto.java
@@ -1,0 +1,19 @@
+package com.consertreservation.application.queue.application.dto;
+
+import com.consertreservation.domain.usertoken.application.dto.ResultUserTokenServiceDto;
+import lombok.Builder;
+
+@Builder
+public record ResultQueueServiceDto(
+        Long userId,
+        Long waitingOrder,
+        String tokenStatus
+) {
+
+    public static ResultQueueServiceDto from(ResultUserTokenServiceDto dto) {
+        return ResultQueueServiceDto.builder()
+                .userId(dto.userId())
+                .tokenStatus(dto.tokenStatus())
+                .build();
+    }
+}

--- a/src/main/java/com/consertreservation/application/queue/constant/QueueConst.java
+++ b/src/main/java/com/consertreservation/application/queue/constant/QueueConst.java
@@ -1,0 +1,8 @@
+package com.consertreservation.application.queue.constant;
+
+public final class QueueConst {
+
+    public static final String WAITING_QUEUE = "waiting-queue";
+    public static final String ACTIVE_QUEUE = "active-queue";
+    public static final int COUNT_OF_ACTIVE_USER_TOKEN = 250;
+}

--- a/src/main/java/com/consertreservation/application/redis/RedisService.java
+++ b/src/main/java/com/consertreservation/application/redis/RedisService.java
@@ -1,0 +1,48 @@
+package com.consertreservation.application.redis;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
+import org.springframework.stereotype.Service;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class RedisService {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    public void addItemToSortedSet(String key, String value, double score) {
+        redisTemplate.opsForZSet().add(key, value, score);
+    }
+
+    public Long getItemRank(String key, String value) {
+        return redisTemplate.opsForZSet().rank(key, value);
+    }
+
+    public Set<Object> getItemsInSortedSet(String key, int start, int end) {
+        Set<Object> items = redisTemplate.opsForZSet().range(key, start, end);
+        if (Objects.isNull(items)) {
+            return Set.of();
+        }
+        return items;
+    }
+
+    public void removeItemsInSortedSet(String key, int start, int end) {
+        redisTemplate.opsForZSet().removeRange(key, start, end);
+    }
+
+    public void addItemToHash(String key, String hashKey, String value) {
+        redisTemplate.opsForHash().put(key, hashKey, value);
+    }
+
+    public void deleteAllInHash(String key) {
+        redisTemplate.opsForHash().delete(key);
+    }
+
+    public boolean existInHash(String key, String hashKey) {
+        return Objects.nonNull(redisTemplate.opsForHash().get(key, hashKey));
+    }
+}

--- a/src/main/java/com/consertreservation/config/RedissonConfig.java
+++ b/src/main/java/com/consertreservation/config/RedissonConfig.java
@@ -3,10 +3,16 @@ package com.consertreservation.config;
 import org.redisson.Redisson;
 import org.redisson.api.RedissonClient;
 import org.redisson.config.Config;
+import org.redisson.spring.data.connection.RedissonConnectionFactory;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
 
+@EnableCaching
 @Configuration
 public class RedissonConfig {
 
@@ -22,5 +28,29 @@ public class RedissonConfig {
         Config config = new Config();
         config.useSingleServer().setAddress(REDISSON_HOST_PREFIX + host + ":" + port);
         return Redisson.create(config);
+    }
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return  new RedissonConnectionFactory(redissonClient());
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+
+        // key:value 시리얼라이즈
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+
+        // hash 시리얼라이저
+        redisTemplate.setHashKeySerializer(new StringRedisSerializer());
+        redisTemplate.setHashValueSerializer(new StringRedisSerializer());
+
+        // default 시리얼라이저
+        redisTemplate.setDefaultSerializer(new StringRedisSerializer());
+
+        return redisTemplate;
     }
 }

--- a/src/main/java/com/consertreservation/domain/usertoken/application/dto/ResultUserTokenServiceDto.java
+++ b/src/main/java/com/consertreservation/domain/usertoken/application/dto/ResultUserTokenServiceDto.java
@@ -1,6 +1,8 @@
 package com.consertreservation.domain.usertoken.application.dto;
 
 import java.util.UUID;
+
+import com.consertreservation.domain.usertoken.usecase.dto.ResultUserTokenUseCaseDto;
 import lombok.Builder;
 
 @Builder
@@ -10,4 +12,13 @@ public record ResultUserTokenServiceDto(
         String tokenStatus,
         int waitingOrder
 ) {
+
+    public static ResultUserTokenServiceDto from(ResultUserTokenUseCaseDto usertoken) {
+        return ResultUserTokenServiceDto
+                .builder()
+                .id(usertoken.id())
+                .userId(usertoken.userId())
+                .tokenStatus(usertoken.tokenStatus())
+                .build();
+    }
 }

--- a/src/main/java/com/consertreservation/domain/usertoken/components/UserTokenComponent.java
+++ b/src/main/java/com/consertreservation/domain/usertoken/components/UserTokenComponent.java
@@ -84,4 +84,12 @@ public class UserTokenComponent {
                 .orElseThrow(() -> new UserTokenException(NOT_FOUND, "유저 토큰을 찾을 수 없습니다"));
         userToken.expire();
     }
+
+    @Transactional(readOnly = true)
+    public List<UserTokenDto> getUserTokens(List<Long> userIds) {
+        return userTokenReaderRepository.getUserTokensByUserId(userIds)
+                .stream()
+                .map(UserTokenDto::from)
+                .toList();
+    }
 }

--- a/src/main/java/com/consertreservation/domain/usertoken/infra/UserTokenReaderCustomRepository.java
+++ b/src/main/java/com/consertreservation/domain/usertoken/infra/UserTokenReaderCustomRepository.java
@@ -62,4 +62,11 @@ public class UserTokenReaderCustomRepository implements UserTokenReaderRepositor
                 .where(userToken.id.in(ids))
                 .fetch();
     }
+
+    @Override
+    public List<UserToken> getUserTokensByUserId(List<Long> userIds) {
+        return queryFactory.selectFrom(userToken)
+                .where(userToken.userId.in(userIds))
+                .fetch();
+    }
 }

--- a/src/main/java/com/consertreservation/domain/usertoken/respositories/UserTokenReaderRepository.java
+++ b/src/main/java/com/consertreservation/domain/usertoken/respositories/UserTokenReaderRepository.java
@@ -11,4 +11,5 @@ public interface UserTokenReaderRepository {
     List<UserToken> getWaitOfUserTokensLimited(int count);
     List<UserToken> getSuccessOfUserTokensLimited(int count);
     List<UserToken> getUserTokens(List<UUID> id);
+    List<UserToken> getUserTokensByUserId(List<Long> userIds);
 }

--- a/src/main/java/com/consertreservation/domain/usertoken/usecase/GetUserTokensUseCase.java
+++ b/src/main/java/com/consertreservation/domain/usertoken/usecase/GetUserTokensUseCase.java
@@ -1,0 +1,22 @@
+package com.consertreservation.domain.usertoken.usecase;
+
+import com.consertreservation.domain.usertoken.components.UserTokenComponent;
+import com.consertreservation.domain.usertoken.usecase.dto.ResultUserTokenUseCaseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class GetUserTokensUseCase {
+
+    private final UserTokenComponent userTokenComponent;
+
+    public List<ResultUserTokenUseCaseDto> executeUserTokens(List<Long> userIds) {
+        return userTokenComponent.getUserTokens(userIds)
+                .stream()
+                .map(ResultUserTokenUseCaseDto::from)
+                .toList();
+    }
+}

--- a/src/main/java/com/consertreservation/domain/usertoken/usecase/dto/ResultUserTokenUseCaseDto.java
+++ b/src/main/java/com/consertreservation/domain/usertoken/usecase/dto/ResultUserTokenUseCaseDto.java
@@ -1,6 +1,8 @@
 package com.consertreservation.domain.usertoken.usecase.dto;
 
 import java.util.UUID;
+
+import com.consertreservation.domain.usertoken.components.dto.UserTokenDto;
 import lombok.Builder;
 
 @Builder
@@ -10,4 +12,12 @@ public record ResultUserTokenUseCaseDto(
         String tokenStatus,
         int waitingOrder
 ) {
+
+    public static ResultUserTokenUseCaseDto from(UserTokenDto userTokenDto){
+        return ResultUserTokenUseCaseDto.builder()
+                .id(userTokenDto.id())
+                .userId(userTokenDto.userId())
+                .tokenStatus(userTokenDto.tokenStatus())
+                .build();
+    }
 }


### PR DESCRIPTION
## 정책
1. 10분마다 대기열 큐에 있는 250명을 활성화 큐에 넣는다.
2. 활성화 큐에 있는 유저만 해당 서비스를 이용 할 수가 있다.
3. 활성화 큐에 있는 유저는 10분 동안만 서비스를 이용 할 수가 있다.

## 설계
-  대기열 큐 자료구조는 **sorted set**입니다.
    1. 먼저 들어온 유저가 나중에 들어온 유저보다 먼저 활성화 큐에 진입 해야 합니다. 
    => 공정성을 지키기 위해서입니다.
    2. score는 유저가 대기열큐에 들어온 시간으로 하였습니다.
    => 1번을 지키기 위해서 이렇게 진행 했습니다.
- 활성화 큐 자료구조는 **hash**입니다.
    1. 활성화 큐의 목적은 해당 유저가 활성화가 되어 있는지 조회입니다. 따라서 Hashkey 값을 유저로 했을때, 조회 성능은 O(1) 이므로, hash를 사용했습니다.

## 진행한 TASK
- [x] 대기열 큐, 활성화 큐 생성
- [x] 유저가 권한이 있는지 확인하는 로직을 db 에서 조회 -> 활성화 큐에서 조회 하도록 수정
- [x] 유저 토큰 발급시 대기열큐에 추가
- [x] 크론 동작(10분마다 실행)
  1. 기존 활성화큐 삭제
  2. 대기열큐에서 250명을 가져옴
  3. 250명을 활성화 큐에 넣음
  4. 해당 250명을 대기열 큐에서 삭제